### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/cloud/v1alpha1/register.go
+++ b/apis/cloud/v1alpha1/register.go
@@ -53,7 +53,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&CloudProvider{},
 		&CloudProviderList{},
 
@@ -64,7 +65,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&MachineTypeList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/cluster/v1alpha1/register.go
+++ b/apis/cluster/v1alpha1/register.go
@@ -48,7 +48,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ClusterInfo{},
 		&ClusterInfoList{},
 
@@ -59,7 +60,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ClusterUserAuthList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/config/v1alpha1/register.go
+++ b/apis/config/v1alpha1/register.go
@@ -53,11 +53,13 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&AceSetupConfig{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
