### PR TITLE
Add OfflineLicense to cluster ImportOptions

### DIFF
--- a/apis/cluster/types.go
+++ b/apis/cluster/types.go
@@ -77,6 +77,9 @@ type ImportOptions struct {
 	BasicInfo  BasicInfo        `json:"basicInfo,omitempty"`
 	Provider   ProviderOptions  `json:"provider,omitempty"`
 	Components ComponentOptions `json:"components,omitempty"`
+	// OfflineLicense is a raw PEM encoded license for the cluster being imported.
+	// Offline installers can't reach the licensor, so the license is supplied by the user.
+	OfflineLicense string `json:"offlineLicense,omitempty"`
 }
 
 type ConnectOptions struct {


### PR DESCRIPTION
Offline (air-gapped) installers can't reach the licensor, so the license for the cluster being imported has to be supplied by the user in the import request.

Adds `offlineLicense` (raw PEM) to `ImportOptions`. b3 consumes it in the cluster import flow: for a self-managed cluster it goes into the license-proxyserver HelmRelease values, and for a spoke it goes into the `license-proxyserver-licenses` secret in the spoke's hub namespace.